### PR TITLE
feat(detail-page): extend title with inclusion

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -217,9 +217,8 @@ export class Renderer {
 
     console.info(chalk.green`Register concat helper...`);
 
-    Handlebars.registerHelper('concat', (string1: string, string2: string) => {
-      console.log(string1);
-      return string1 + string2;
+    Handlebars.registerHelper('concat', (string1: string, string2: string, string3?: string, string4?: string) => {
+      return string1 + string2 + (string3 ? string3 : '') + (string4 ? string4 : '');
     });
 
     console.info(chalk.green`Register if equal helper...`);

--- a/template/de/_detail.html
+++ b/template/de/_detail.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="de">
 {{#if description}}
-{{>head baseHref=baseHref pageTitle=(concat title " gesucht") pageDesc=description lang="de"}}
+{{>head baseHref=baseHref pageTitle=(concat title " " (translate "inclusion" "de") " gesucht") pageDesc=description lang="de"}}
 {{/if}}
 {{#unless description}}
-{{>head baseHref=baseHref pageTitle=(concat title " gesucht") pageDesc="We believe two heads are always better than one. And a whole team of heads is even better. That’s how we work. With no alpha leaders and no beta teams." lang="de"}}
+{{>head baseHref=baseHref pageTitle=(concat title " " (translate "inclusion" "de") " gesucht") pageDesc="We believe two heads are always better than one. And a whole team of heads is even better. That’s how we work. With no alpha leaders and no beta teams." lang="de"}}
 {{/unless}}
 <body data-theme="green">
 {{>svgsprite}}

--- a/template/en/_detail.html
+++ b/template/en/_detail.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
     {{#if description}}
-        {{>head baseHref=baseHref pageTitle=(concat title " wanted") pageDesc=description lang="en"}}
+        {{>head baseHref=baseHref pageTitle=(concat title "" (translate "inclusion" "en") " wanted") pageDesc=description lang="en"}}
     {{/if}}
     {{#unless description}}
-        {{>head baseHref=baseHref pageTitle=(concat title " wanted") pageDesc="We believe two heads are always better than one. And a whole team of heads is even better. That’s how we work. With no alpha leaders and no beta teams." lang="en"}}
+        {{>head baseHref=baseHref pageTitle=(concat title " " (translate "inclusion"  "en") " wanted") pageDesc="We believe two heads are always better than one. And a whole team of heads is even better. That’s how we work. With no alpha leaders and no beta teams." lang="en"}}
     {{/unless}}
     <body data-theme="green">
         {{>svgsprite}}


### PR DESCRIPTION
this fixes the title text for detail pages to also include the gender string